### PR TITLE
Make a simpler interface via a (non-spec) method `#listen`.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    servent (0.1.0)
+    servent (0.0.1)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -29,15 +29,8 @@ gem 'servent'
 #   id: 42
 #   data: Omg! Hello World.
 
-events = Queue.new
-
 event_source = Servent::EventSource.new("http://example.org/event-source")
 event_source.on_message do |message|
-  events.push message
-end
-event_source.start
-
-while (event = events.pop)
   puts "Event type: #{event.type}"
   puts "Event body: #{event.body}"
 
@@ -49,6 +42,10 @@ while (event = events.pop)
   #   ```
   # And wait for the next event to arrive.
 end
+
+# join the internal event source thread
+# so we can receive event until it terminates:
+event_source.listen
 ```
 
 ## Development

--- a/hypotesis/consumer.rb
+++ b/hypotesis/consumer.rb
@@ -1,12 +1,13 @@
 require "net/http"
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "servent"
+require "pp"
 
-q = Queue.new
-
-trap :INT do
-  q << nil
-end
+#q = Queue.new
+#
+#trap :INT do
+#  q << nil
+#end
 
 #Thread.new do
 #  uri = URI("http://localhost:9292/omg")
@@ -25,13 +26,13 @@ end
 
 event_source = Servent::EventSource.new("http://localhost:9292/omg")
 event_source.on_message do |message|
-  q.push message
+  #q.push message
+  pp message
 end
-event_source.start
+event_source.start.join
 
-
-while (chunk = q.pop)
-  puts chunk
-end
+#while (chunk = q.pop)
+#  puts chunk
+#end
 
 puts "bye"

--- a/hypotesis/consumer.rb
+++ b/hypotesis/consumer.rb
@@ -29,7 +29,7 @@ event_source.on_message do |message|
   #q.push message
   pp message
 end
-event_source.start.join
+event_source.listen
 
 #while (chunk = q.pop)
 #  puts chunk

--- a/lib/servent/event_source.rb
+++ b/lib/servent/event_source.rb
@@ -32,6 +32,10 @@ module Servent
       }
     end
 
+    def listen(http_starter = Net::HTTP)
+      start(http_starter).join
+    end
+
     def on_open(&open_block)
       @open_blocks << open_block
     end

--- a/lib/servent/version.rb
+++ b/lib/servent/version.rb
@@ -1,3 +1,3 @@
 module Servent
-  VERSION = "0.1.0".freeze
+  VERSION = "0.0.1".freeze
 end

--- a/spec/servent/event_source_spec.rb
+++ b/spec/servent/event_source_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Servent::EventSource do
   }
   let(:headers) { { "Accept" => "text/event-stream" } }
   let(:response_headers) { { "Content-Type" => "text/event-stream" } }
-
   let(:stub) {
     stub_request(:get, url)
       .with(headers: headers)
@@ -85,6 +84,27 @@ RSpec.describe Servent::EventSource do
 
         event_source.start(http_starter).join
       end
+    end
+  end
+
+  describe "#listen" do
+    it "starts and joins the internal thread in one go" do
+      fake_thread = double(Thread)
+      allow(event_source).to receive(:start).and_return fake_thread
+      expect(fake_thread).to receive(:join)
+
+      event_source.listen
+    end
+
+    it "repasses 'http_starter' if one is passed to listen" do
+      http_starter = double(Net::HTTP)
+      fake_thread = double(Thread)
+      allow(event_source).to receive(:start)
+        .with(http_starter)
+        .and_return fake_thread
+      expect(fake_thread).to receive(:join)
+
+      event_source.listen http_starter
     end
   end
 


### PR DESCRIPTION
# What is that for ❓ 

It adds a non-specified method to mix: `#listen`.
This will start the request and join the internal thread in one go.
If the users are not interested in handling the thread by themselves, they can just call `#listen` on their long-running scripts.

## How it works ❓ 

`#listen` just wraps a chained invokation: `start.join`.